### PR TITLE
Enforce HTTPS for Yodeck compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,10 @@ Content designed for large-format touchscreens in high-traffic locations on OSU'
 ## Site URLs
 
 - Production Deployment URL: https://osu-sustainability-office.github.io/sustainability-kiosks/#/
-- Test Deployment URL: http://sustainability-kiosks.s3-website-us-west-2.amazonaws.com/#/
+- Test Deployment URL (http): http://sustainability-kiosks.s3-website-us-west-2.amazonaws.com/#/
+- Test Deployment URL's (https):
+  - https://sustainability-kiosks.s3.us-west-2.amazonaws.com/index.html#/
+  - https://sustainability-kiosks.s3.us-west-2.amazonaws.com/index.html#/sec
 
 ## Site Setup
 

--- a/src/components/main.vue
+++ b/src/components/main.vue
@@ -22,7 +22,7 @@
         <el-col> </el-col>
         <el-col> </el-col>
         <el-col>
-          <a href="http://fa.oregonstate.edu/sustainability"
+          <a href="https://fa.oregonstate.edu/sustainability"
             ><el-button id="myBtn">Sustainability Website</el-button></a
           >
         </el-col>


### PR DESCRIPTION
## Error Screenshot
![image](https://github.com/OSU-Sustainability-Office/sustainability-kiosks/assets/82061589/d412ab02-276f-4f54-ad19-ac6246a2bc9a)

## Test Deployment
- Changed Kiosk URL in Yodeck to https://sustainability-kiosks.s3.us-west-2.amazonaws.com/index.html#/ (s3 test deployment) for testing, seemed to work
- I did enable the Yodeck browser extension, not sure if it matters, but it didn't seem like the original cause of the bug
![image](https://github.com/OSU-Sustainability-Office/sustainability-kiosks/assets/82061589/7bef3049-2a1c-417e-ad40-b1067eb48b6f)
![image](https://github.com/OSU-Sustainability-Office/sustainability-kiosks/assets/82061589/6252c96e-bc97-498f-9b5d-5f8500d987a1)
