### PR TITLE
Media rotation refresh

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -32,6 +32,7 @@ export default {
       timeDiffUnix: 0,
       refreshInterval: 300, // 5 minutes refresh interval. Time in seconds (lower for debug)
       inactivityTimeout: 30000, // 30 seconds of inactivity. Time in milliseconds
+      inactivityTimeoutDefault: 30000, // 30 seconds of inactivity. Time in milliseconds
       inactivityTimer: null,
       mediaList: [],
     }
@@ -74,6 +75,18 @@ export default {
     },
     // creates a timer that routes to the Carousel page after time is up
     createInactivityTimer () {
+
+      // refresh media
+      this.fetchMedia();
+
+      // if there is no media, set the inactivity timeout to the longer refresh interval
+      // otherwise use the default inactivity timeout
+      if (this.mediaList.length === 0) {
+        this.inactivityTimeout = this.refreshInterval * 1000;
+      } else {
+        this.inactivityTimeout = this.inactivityTimeoutDefault;
+      };
+
       this.inactivityTimer = setTimeout(() => {
         this.$router.push({
           name: 'Carousel',
@@ -115,10 +128,9 @@ export default {
     await this.fetchMedia()
 
     // if there is media, create a timer and click listener for media rotation
-    if (this.mediaList.length > 0) {
-      this.$el.addEventListener('click', this.navigateToHomepage)
-      this.createInactivityTimer()
-    }
+    this.$el.addEventListener('click', this.navigateToHomepage)
+    this.createInactivityTimer()
+
   },
   beforeDestroy () {
     clearInterval(this.timer)

--- a/src/App.vue
+++ b/src/App.vue
@@ -34,7 +34,7 @@ export default {
       inactivityTimeout: 30000, // 30 seconds of inactivity. Time in milliseconds
       inactivityTimeoutDefault: 30000, // 30 seconds of inactivity. Time in milliseconds
       inactivityTimer: null,
-      mediaList: [],
+      mediaList: []
     }
   },
   methods: {
@@ -57,27 +57,28 @@ export default {
     },
     // fetch media from AWS bucket
     async fetchMedia () {
-      const bucketURL = "https://osu-kiosk-media.s3.us-west-2.amazonaws.com"
+      const bucketURL = 'https://osu-kiosk-media.s3.us-west-2.amazonaws.com'
 
       // fetch media list from S3 bucket
       try {
         const response = await axios.get(bucketURL)
-        const parser = new DOMParser();
-        const xmlDoc = parser.parseFromString(response.data, "text/xml");
-        const keys = xmlDoc.getElementsByTagName("Key");
+        const parser = new DOMParser()
+        const xmlDoc = parser.parseFromString(response.data, 'text/xml')
+        const keys = xmlDoc.getElementsByTagName('Key')
 
-        this.mediaList = Array.from(keys).map(key => `${bucketURL}/${key.textContent}`);
+        this.mediaList = Array.from(keys).map(
+          (key) => `${bucketURL}/${key.textContent}`
+        )
       } catch (error) {
         console.error('Error fetching media:', error)
       }
 
-      console.log("Media list:", this.mediaList);
+      console.log('Media list:', this.mediaList)
     },
     // creates a timer that routes to the Carousel page after time is up
     createInactivityTimer () {
-
       // refresh media
-      this.fetchMedia();
+      this.fetchMedia()
 
       this.inactivityTimer = setTimeout(() => {
         this.$router.push({
@@ -91,7 +92,6 @@ export default {
       }, this.inactivityTimeout)
     },
     navigateToHomepage () {
-
       // clear timer
       if (this.inactivityTimer) {
         clearTimeout(this.inactivityTimer)
@@ -119,10 +119,9 @@ export default {
     // get media for rotation
     await this.fetchMedia()
 
-    //create a timer and click listener for media rotation
+    // create a timer and click listener for media rotation
     this.$el.addEventListener('click', this.navigateToHomepage)
     this.createInactivityTimer()
-
   },
   beforeDestroy () {
     clearInterval(this.timer)
@@ -149,11 +148,11 @@ export default {
       }
     },
     mediaList: function (newList, oldList) {
-      console.log("Media length: ", newList.length);
+      console.log('Media length: ', newList.length)
       if (newList.length === 0) {
-        this.inactivityTimeout = this.refreshInterval * 1000;
+        this.inactivityTimeout = this.refreshInterval * 1000
       } else {
-        this.inactivityTimeout = this.inactivityTimeoutDefault;
+        this.inactivityTimeout = this.inactivityTimeoutDefault
       }
     },
     $route (to, from) {

--- a/src/App.vue
+++ b/src/App.vue
@@ -30,7 +30,7 @@ export default {
       url: process.env.VUE_APP_HOST_ADDRESS,
       modifiedDateUnix: 0,
       timeDiffUnix: 0,
-      refreshInterval: 300, // 5 minutes refresh interval. Time in seconds (lower for debug)
+      refreshInterval: 600, // 10 minutes refresh interval. Time in seconds (lower for debug)
       inactivityTimeout: 30000, // 30 seconds of inactivity. Time in milliseconds
       inactivityTimeoutDefault: 30000, // 30 seconds of inactivity. Time in milliseconds
       inactivityTimer: null,
@@ -55,7 +55,7 @@ export default {
         // Log the modifiedDateUnix and timeDiffUnix here if needed for debug
       })
     },
-    // fetch media from Google Drive folder
+    // fetch media from AWS bucket
     async fetchMedia () {
       const bucketURL = "https://osu-kiosk-media.s3.us-west-2.amazonaws.com"
 
@@ -78,14 +78,6 @@ export default {
 
       // refresh media
       this.fetchMedia();
-
-      // if there is no media, set the inactivity timeout to the longer refresh interval
-      // otherwise use the default inactivity timeout
-      if (this.mediaList.length === 0) {
-        this.inactivityTimeout = this.refreshInterval * 1000;
-      } else {
-        this.inactivityTimeout = this.inactivityTimeoutDefault;
-      };
 
       this.inactivityTimer = setTimeout(() => {
         this.$router.push({
@@ -127,7 +119,7 @@ export default {
     // get media for rotation
     await this.fetchMedia()
 
-    // if there is media, create a timer and click listener for media rotation
+    //create a timer and click listener for media rotation
     this.$el.addEventListener('click', this.navigateToHomepage)
     this.createInactivityTimer()
 
@@ -154,6 +146,14 @@ export default {
         setTimeout(() => {
           window.location.reload()
         }, 10000)
+      }
+    },
+    mediaList: function (newList, oldList) {
+      console.log("Media length: ", newList.length);
+      if (newList.length === 0) {
+        this.inactivityTimeout = this.refreshInterval * 1000;
+      } else {
+        this.inactivityTimeout = this.inactivityTimeoutDefault;
       }
     },
     $route (to, from) {

--- a/src/components/carousel.vue
+++ b/src/components/carousel.vue
@@ -28,7 +28,7 @@ export default {
   data () {
     return {
       imgIndex: 0,
-      rotationInterval: 10000, // time in ms (10 seconds)
+      rotationInterval: 15000 // time in ms (15 seconds)
     }
   },
   computed: {


### PR DESCRIPTION
Since three of the four kiosks don't refresh, we need to refresh the media list in between rotations to keep up to date and prevent showing a broken image. If there isn't any media, a longer interval is set before checking again. 