### PR TITLE
Iframes and Image Caching

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -10,7 +10,7 @@
   <el-container class="app">
     <el-header class="header"> </el-header>
     <el-main class="main" ref="main">
-      <router-view />
+      <router-view @iframeChanged="iframe = $event" />
     </el-main>
   </el-container>
 </template>
@@ -31,9 +31,11 @@ export default {
       modifiedDateUnix: 0,
       timeDiffUnix: 0,
       refreshInterval: 600, // 10 minutes refresh interval. Time in seconds (lower for debug)
+      mediaCheckTimer: null,
+      mediaCheckInterval: 43200000, // 12 hours. Time in ms
       inactivityTimeout: 30000, // 30 seconds of inactivity. Time in milliseconds
-      inactivityTimeoutDefault: 30000, // 30 seconds of inactivity. Time in milliseconds
       inactivityTimer: null,
+      iframe: null,
       mediaList: []
     }
   },
@@ -95,8 +97,6 @@ export default {
       } catch (error) {
         console.error('Error fetching media:', error)
       }
-
-      console.log('Media list:', this.mediaList)
     },
     // creates a timer that routes to the Carousel page after time is up
     createInactivityTimer () {
@@ -118,9 +118,11 @@ export default {
       }
 
       // set a new timer for navigating to image carousel
-      this.createInactivityTimer()
+      if (!this.iframe) this.createInactivityTimer()
 
-      this.$router.push('/')
+      if (!this.iframe && this.$route.path === '/carousel') {
+        this.$router.push('/')
+      }
     }
   },
   async created () {
@@ -134,11 +136,16 @@ export default {
         this.fetchLastModified,
         this.refreshInterval * 1000
       ) // setInterval expects milliseconds
+
+      // check for new media
+      this.mediaCheckTimer = setInterval(
+        this.fetchMedia,
+        this.mediaCheckInterval
+      )
     }
 
     // get media for rotation
-    // await this.fetchMedia()
-    console.log('Media list:', this.mediaList)
+    await this.fetchMedia()
 
     // create a timer for media rotation
     this.createInactivityTimer()
@@ -148,6 +155,7 @@ export default {
   },
   beforeDestroy () {
     clearInterval(this.timer)
+    clearInterval(this.mediaCheckTimer)
 
     if (this.inactivityTimer) {
       clearTimeout(this.inactivityTimer)
@@ -171,15 +179,23 @@ export default {
       }
     },
     mediaList: function (newList, oldList) {
-      console.log('Media length: ', newList.length)
       if (newList.length === 0) {
-        this.inactivityTimeout = this.refreshInterval * 1000
-      } else {
-        this.inactivityTimeout = this.inactivityTimeoutDefault
+        clearInterval(this.inactivityTimer)
+      } else if (oldList.length === 0) {
+        this.createInactivityTimer()
       }
     },
     $route (to, from) {
       if (from.path === '/carousel' && to.path !== '/carousel') {
+        this.createInactivityTimer()
+      }
+    },
+    // clear the carousel timer when the iframe is active,
+    // reset it when the iframe is closed
+    iframe: function (newUrl, oldUrl) {
+      if (newUrl) {
+        clearTimeout(this.inactivityTimer)
+      } else {
         this.createInactivityTimer()
       }
     }

--- a/src/components/carousel.vue
+++ b/src/components/carousel.vue
@@ -1,9 +1,6 @@
 <template>
   <el-row class="img-container" type="flex" justify="center" align="middle">
-    <img
-      src="@/assets/Fall_Hiring_Poster_24.png"
-      alt="Fall hiring poster with QR codes"
-    />
+    <img :src="currentImage" alt="Hiring or Event posting" />
     <div v-if="touchScreenIndicator">
       <h1 class="text-content">
         Tap to learn more about the Sustainability Office

--- a/src/components/main.vue
+++ b/src/components/main.vue
@@ -22,30 +22,100 @@
         <el-col> </el-col>
         <el-col> </el-col>
         <el-col>
-          <a href="https://fa.oregonstate.edu/sustainability"
-            ><el-button id="myBtn">Sustainability Website</el-button></a
+          <el-button
+            id="myBtn"
+            @click="setIframe('https://fa.oregonstate.edu/sustainability')"
+            >Sustainability Website</el-button
           >
         </el-col>
         <el-col>
-          <a
-            href="https://osu-sustainability-office.github.io/sustainability_jeopardy/"
-            ><el-button id="myBtn">Sustainability Jeopardy</el-button></a
+          <el-button
+            id="myBtn"
+            @click="
+              setIframe(
+                'https://osu-sustainability-office.github.io/sustainability_jeopardy/'
+              )
+            "
+            >Sustainability Jeopardy</el-button
           >
         </el-col>
         <el-col>
-          <a href="https://myco2.sustainability.oregonstate.edu/"
-            ><el-button id="myBtn">Carbon Footprint Calculator</el-button></a
+          <el-button
+            id="myBtn"
+            @click="setIframe('https://myco2.sustainability.oregonstate.edu/')"
+            >Carbon Footprint Calculator</el-button
           >
         </el-col>
         <el-col> </el-col>
         <el-col> </el-col>
       </el-row>
+      <div v-if="iframe" id="iframe-container">
+        <div id="iframe-inactivity-test" @click="resetIframeActivityTester()">
+          <p id="stay-on-page-text">Tap to stay on this page</p>
+        </div>
+        <iframe
+          :src="iframe"
+          width="100%"
+          height="100%"
+          frameborder="0"
+          allowfullscreen
+        ></iframe>
+        <el-button
+          id="home-btn"
+          size="large"
+          icon="el-icon-s-home"
+          circle
+          @click="setIframe(null)"
+        ></el-button>
+      </div>
     </el-col>
   </el-row>
 </template>
 
 <script>
-export default {}
+export default {
+  data () {
+    return {
+      iframe: null,
+      iframeTimer: null,
+      iframeTimeout: 300000, // 5 minutes
+      iframeActivityTestTimeout: 240000 // 4 minutes
+    }
+  },
+  methods: {
+    setIframe (url) {
+      this.iframe = url
+      this.resetIframeTimer()
+      this.$emit('iframeChanged', url)
+    },
+    resetIframeTimer () {
+      // set click tester timer to reset pointer-event to auto
+      setTimeout(() => {
+        this.toggleIframeActivityTester('visible')
+      }, this.iframeActivityTestTimeout)
+
+      clearTimeout(this.iframeTimer)
+      this.iframeTimer = setTimeout(() => {
+        this.iframe = null
+        this.$emit('iframeChanged', null)
+      }, this.iframeTimeout)
+    },
+    resetIframeActivityTester () {
+      this.toggleIframeActivityTester('hidden')
+      this.resetIframeTimer()
+    },
+    toggleIframeActivityTester (visibility) {
+      const iframeActivityDiv = document.getElementById(
+        'iframe-inactivity-test'
+      )
+      iframeActivityDiv.style.visibility =
+        visibility === 'hidden' ? 'hidden' : 'visible'
+    }
+  },
+  beforeDestroy () {
+    clearTimeout(this.iframeTimer)
+  }
+}
 </script>
 
 <style scoped lang="scss">
@@ -123,5 +193,52 @@ video {
 #myBtn:hover {
   background: $--color-white;
   color: $--color-black;
+}
+
+/* iframe styling */
+#iframe-container {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 100;
+  background: white;
+}
+
+#iframe-inactivity-test {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 101;
+  background: rgba(0, 0, 0, 0.5);
+  visibility: hidden;
+}
+
+#stay-on-page-text {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-size: 2em;
+  color: rgba(255, 255, 255, 0.8);
+  text-align: center;
+  width: fit-content;
+  padding: 10px;
+  border-radius: 10px;
+  z-index: 102;
+  background: rgba(0, 0, 0, 0.5);
+}
+
+#home-btn {
+  position: fixed;
+  background-color: #ff4e00;
+  border: none;
+  color: black;
+  bottom: 10px;
+  left: 10px;
+  z-index: 105;
 }
 </style>


### PR DESCRIPTION
Iframes
---
Previously, the buttons on the homepage would lead to outside websites. The kiosks need to refresh themselves periodically (currently set to every 5 minutes) in order to get back to the sustainability page. Loading the webpages in a full-screen iframe gives us more control over the kiosks and helps reduce S3 requests. 

Once an iframe is loaded, two timers are set. The first is a 5-minute timer that will close the iframe. The second is a 4-minute timer that will pop-up a full-screen page asking the user to tap to stay on the current page (iframe). If they tap, both timers are reset and they can continue using the iframe page. If they don't tap, the 5-minute timer will close the iframe and resume the normal operations. The carousel of images will not trigger while the iframe is active. 

A home button sits at the bottom left of the screen to close the iframes. 


Media
---
The list of images is still retrieved from the S3 bucket, but the images themselves now go through CloudFront, which has a higher free-data tier and enables caching along with custom cache-control headers, which are currently set to 7-days. The media is now checked every 12 hours for new images, and gets rid of any old ones and loads the new ones. 

