### PR TITLE
Adjust font path handling for dynamic environments (Local/Staging and Production)

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -7,3 +7,4 @@
  */
 VUE_APP_ROOT_API=http://localhost:3000
 VUE_APP_HOST_ADDRESS=http://localhost:8080
+VUE_APP_FONT_PATH=/fonts/

--- a/.env.production
+++ b/.env.production
@@ -1,3 +1,4 @@
 NODE_ENV=production
 VUE_APP_ROOT_API=
 VUE_APP_HOST_ADDRESS=https://osu-sustainability-office.github.io/sustainability-kiosks/
+VUE_APP_FONT_PATH=/sustainability-kiosks/fonts/

--- a/src/App.vue
+++ b/src/App.vue
@@ -214,33 +214,24 @@ export default {
 }
 </script>
 
-<style>
-@import url("https://fonts.googleapis.com/css?family=Open+Sans");
+<style lang="scss">
+@import "~element-ui/packages/theme-chalk/src/index";
+
 @font-face {
   font-family: "StratumNo2";
-  /* TODO: Fix this sometime to dynamically change the Font URL prefix based on environment
-     In the meantime, use these prefixes (RESET TO PRODUCTION PREFIX BEFORE MERGE!):
-      - local / staging:
-        - "/fonts/"
-      - production:
-        - "/sustainability-kiosks/fonts/"
-  */
-  src: url("/sustainability-kiosks/fonts/StratumNo2-Bold.woff2") format("woff2"),
-    url("/sustainability-kiosks/fonts/StratumNo2-Bold.woff") format("woff"),
-    url("/sustainability-kiosks/fonts/StratumNo2-Bold.ttf") format("truetype"),
-    url("/sustainability-kiosks/fonts/StratumNo2-Bold.svg#StratumNo2-Bold")
-      format("svg");
+  src: url("#{$font-path}StratumNo2-Bold.woff2") format("woff2"),
+       url("#{$font-path}StratumNo2-Bold.woff") format("woff"),
+       url("#{$font-path}StratumNo2-Bold.ttf") format("truetype"),
+       url("#{$font-path}StratumNo2-Bold.svg#StratumNo2-Bold") format("svg");
   font-weight: bold;
   font-style: normal;
 }
+
 body {
   font-family: "Open Sans", sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
-</style>
-<style lang="scss">
-@import "~element-ui/packages/theme-chalk/src/index";
 </style>
 
 <style scoped lang="scss">

--- a/vue.config.js
+++ b/vue.config.js
@@ -12,7 +12,10 @@ module.exports = {
   css: {
     loaderOptions: {
       sass: {
-        prependData: '@import "@/assets/style-variables.scss";'
+        prependData: `
+          @import "@/assets/style-variables.scss";
+          $font-path: "${process.env.VUE_APP_FONT_PATH}";
+          `
       }
     }
   },


### PR DESCRIPTION
**Problem:** Font source had to be manually updated depending on the environment (Local/Staging or Production)
**Solution:** Added the font source to .env.production and .env.development. Updated vue.config.js to prepend the path into a global variable ($font-path). Use the global variable in the App.vue when importing the fonts.
