### PR TITLE
Added logic for using new S3 test folder for media rotation

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -61,16 +61,29 @@ export default {
     async fetchMedia () {
       const listUrl = 'https://osu-kiosk-media.s3.us-west-2.amazonaws.com'
       const imgUrlPrefix = 'https://d3aici5r99iqap.cloudfront.net'
+      const devTestingFolder = 'development-test-images'
 
       // fetch media list from S3 bucket
       try {
         const response = await axios.get(listUrl)
         const parser = new DOMParser()
         const xmlDoc = parser.parseFromString(response.data, 'text/xml')
-        const keys = xmlDoc.getElementsByTagName('Key')
+        const bucketList = xmlDoc.getElementsByTagName('Key')
+
+        // filter out the key for the folder, and get image keys based on prod or dev
+        let keys = []
+        for (const key of bucketList) {
+          const keyText = key.textContent
+
+          if (process.env.NODE_ENV === 'development') {
+            if (keyText.includes(devTestingFolder) && !keyText.endsWith('/')) { keys.push(keyText) }
+          } else {
+            if (!key.textContent.includes(devTestingFolder)) { keys.push(key.textContent) }
+          }
+        }
 
         this.fetchedMediaList = Array.from(keys).map(
-          (key) => `${imgUrlPrefix}/${key.textContent}`
+          (key) => `${imgUrlPrefix}/${key}`
         )
 
         // remove any old images


### PR DESCRIPTION
I added a new folder into the S3 media rotation bucket:

![image](https://github.com/user-attachments/assets/8cbc5157-83e8-44ea-84c4-ee326a3c5a6b)

It currently has two images, kiosk-test 1 and 2. Kiosk test 3 is in the main bucket. In development mode, you can see images 1 and 2 in the rotation. In [production and staging](http://sustainability-kiosks.s3-website-us-west-2.amazonaws.com/), you will only see image 3 in the rotation. 

After testing and merging this PR, we need to delete the test image in the main bucket, otherwise it will continue to show up on the kiosks. 

- [ ] Delete kiosk-test-3.jpg from S3 bucket